### PR TITLE
fix(modules/darwin): set `primaryUser`

### DIFF
--- a/modules/darwin/system.nix
+++ b/modules/darwin/system.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  vars,
+  ...
+}: {
   system = {
     stateVersion = 5;
 
@@ -8,6 +12,7 @@
       # so we do not need to logout and login again to make the changes take effect.
       /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
     '';
+    primaryUser = vars.username;
 
     defaults = {
       menuExtraClock.Show24Hour = true;

--- a/modules/darwin/system.nix
+++ b/modules/darwin/system.nix
@@ -6,12 +6,6 @@
   system = {
     stateVersion = 5;
 
-    # activationScripts are executed every time you boot the system or run `nixos-rebuild` / `darwin-rebuild`.
-    activationScripts.postUserActivation.text = ''
-      # activateSettings -u will reload the settings from the database and apply them to the current session,
-      # so we do not need to logout and login again to make the changes take effect.
-      /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
-    '';
     primaryUser = vars.username;
 
     defaults = {


### PR DESCRIPTION
- set `primaryUser`
- remove `activationScripts.postUserActivation`
- related: https://github.com/nix-darwin/nix-darwin/issues/1457