### PR TITLE
fix: properly set sessionVariables with home-manager

### DIFF
--- a/home/nixos/programs/bash.nix
+++ b/home/nixos/programs/bash.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  config,
+  ...
+}: {
+  options = {
+    bash.enable = lib.mkEnableOption "Whether to enable bash";
+  };
+
+  config = lib.mkIf config.bash.enable {
+    programs.bash = {
+      enable = true;
+    };
+  };
+}

--- a/hosts/desktop-nzxt-h1/home.nix
+++ b/hosts/desktop-nzxt-h1/home.nix
@@ -30,6 +30,7 @@
   zellij.enable = true;
   zoxide.enable = true;
 
+  bash.enable = true;
   rofi.enable = true;
   sway.enable = true;
   waybar.enable = true;


### PR DESCRIPTION
[Trouble setting environment variables in home manager](https://discourse.nixos.org/t/trouble-setting-environment-variables-in-home-manager/43734/6)

> Note that to work correctly, home-manager needs your shell to source
> `~/.nix-profile/etc/profile.d/hm-session-vars.sh`. The most convenient way to
> do so is to have `home-manager` manage your whole shell configuration, e.g.,
> `programs.bash.enable = true;` or `programs.zsh.enable = true;`
