### PR TITLE
fix: incorrect input argument

### DIFF
--- a/home/nixos/programs/sway/default.nix
+++ b/home/nixos/programs/sway/default.nix
@@ -18,7 +18,7 @@
       };
       checkConfig = false;
 
-      config = import ./config.nix {inherit pkgs config lib;};
+      config = import ./config.nix {inherit config pkgs lib inputs sources;};
       extraConfig = ''
         corner_radius 4
         shadows enable


### PR DESCRIPTION
- fix incorrect input argument to `config.nix`
