### PR TITLE
chore: change `eloston-chromium` to `ungoogled-chromium`

### DIFF
--- a/modules/darwin/apps.nix
+++ b/modules/darwin/apps.nix
@@ -43,7 +43,7 @@
 
     casks = [
       "ghostty"
-      "eloston-chromium" # Ungoogled Chromium
+      "ungoogled-chromium"
       "karabiner-elements"
       "raycast"
       "colemak-dh"


### PR DESCRIPTION
- replace the `eloston-chromium` cask with `ungoogled-chromium`